### PR TITLE
Support CURL_INOUT events

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -39,6 +39,16 @@ target_link_libraries(lift_async_batch_requests PRIVATE lifthttp ${LIFT_CURL_LIB
 target_compile_features(lift_async_batch_requests PRIVATE cxx_std_17)
 target_include_directories(lift_async_batch_requests SYSTEM PRIVATE ${CURL_INCLUDE})
 
+
+### async_post_requests ###
+set(ASYNC_POST_REQUESTS_SOURCE_FILES
+    examples/async_post_requests.cpp
+)
+add_executable(lift_async_post_requests ${ASYNC_POST_REQUESTS_SOURCE_FILES})
+target_link_libraries(lift_async_post_requests PRIVATE lifthttp ${LIFT_CURL_LIBRARY_DEPENDENCIES} ${LIFT_SYSTEM_LIBRARY_DEPENDENCIES})
+target_compile_features(lift_async_post_requests PRIVATE cxx_std_17)
+target_include_directories(lift_async_post_requests SYSTEM PRIVATE ${CURL_INCLUDE})
+
 ### query_builder ###
 set(QUERY_BUILDER_SOURCE_FILES
     examples/query_builder.cpp

--- a/examples/async_batch_requests.cpp
+++ b/examples/async_batch_requests.cpp
@@ -32,6 +32,9 @@ static auto on_complete(lift::RequestHandle request) -> void
     case lift::RequestStatus::DOWNLOAD_ERROR:
         std::cout << "Error occurred in CURL write callback: " << request->GetUrl() << std::endl;
         break;
+    case lift::RequestStatus::ERROR_FAILED_TO_START:
+        std::cout << "Error trying to start a request: " << request->GetUrl() << std::endl;
+        break;
     case lift::RequestStatus::ERROR:
         std::cout << "RequestHandle had an unrecoverable error: " << request->GetUrl() << std::endl;
         break;

--- a/examples/async_post_requests.cpp
+++ b/examples/async_post_requests.cpp
@@ -1,0 +1,92 @@
+#include <lift/Lift.h>
+
+#include <iostream>
+
+static auto on_complete(lift::RequestHandle request) -> void
+{
+    switch (request->GetCompletionStatus()) {
+        case lift::RequestStatus::SUCCESS:
+            std::cout
+                << "Completed " << request->GetUrl()
+                << " ms:" << request->GetTotalTime().count() << std::endl;
+            break;
+        case lift::RequestStatus::CONNECT_ERROR:
+            std::cout << "Unable to connect to: " << request->GetUrl() << std::endl;
+            break;
+        case lift::RequestStatus::CONNECT_DNS_ERROR:
+            std::cout << "Unable to lookup DNS entry for: " << request->GetUrl() << std::endl;
+            break;
+        case lift::RequestStatus::CONNECT_SSL_ERROR:
+            std::cout << "SSL Error for: " << request->GetUrl() << std::endl;
+            break;
+        case lift::RequestStatus::TIMEOUT:
+            std::cout << "Timeout: " << request->GetUrl() << std::endl;
+            break;
+        case lift::RequestStatus::RESPONSE_EMPTY:
+            std::cout << "No response received: " << request->GetUrl() << std::endl;
+            break;
+        case lift::RequestStatus::DOWNLOAD_ERROR:
+            std::cout << "Error occurred in CURL write callback: " << request->GetUrl() << std::endl;
+            break;
+        case lift::RequestStatus::ERROR_FAILED_TO_START:
+            std::cout << "Error trying to start a request: " << request->GetUrl() << std::endl;
+            break;
+        case lift::RequestStatus::ERROR:
+            std::cout << "RequestHandle had an unrecoverable error: " << request->GetUrl() << std::endl;
+            break;
+        case lift::RequestStatus::BUILDING:
+        case lift::RequestStatus::EXECUTING:
+            std::cout
+                << "RequestHandle is in an invalid state: "
+                << to_string(request->GetCompletionStatus()) << std::endl;
+            break;
+    }
+}
+
+int main(int argc, char** argv) {
+    if (argc != 3) {
+        std::cout << "Please include host and data." << std::endl;
+        return 0;
+    }
+
+    using namespace std::chrono_literals;
+    std::string host{argv[1]};
+    std::string data{argv[2]};
+
+    // Initialize must be called first before using the LiftHttp library.
+    lift::GlobalScopeInitializer lift_init {};
+
+    lift::EventLoop event_loop;
+    auto& request_pool = event_loop.GetRequestPool();
+
+    auto count = 0;
+
+    while (count < 100)
+    {
+        ++count;
+
+        auto request = request_pool.Produce(host, on_complete, 60'000ms);
+        request->SetRequestData(data);
+        request->SetMethod(lift::http::Method::POST);
+        request->SetFollowRedirects(true);
+        request->SetVersion(lift::http::Version::V1_1);
+//        request->AddHeader("Expect", "");
+
+        /**
+         * This will 'move' all of the Request objects into the event loop.
+         * The values in the 'requests' vector are now no longer valid.  This
+         * example intentionally has 'requests' go out of scope to further
+         * demonstrate this.
+         */
+        event_loop.StartRequest(std::move(request));
+    }
+
+    std::this_thread::sleep_for(100ms); // just to be sure still gets kicked off
+
+    // Now wait for all the requests to finish before cleaning up.
+    while (event_loop.GetActiveRequestCount() > 0) {
+        std::this_thread::sleep_for(100ms);
+    }
+
+    return 0;
+}

--- a/inc/lift/EventLoop.h
+++ b/inc/lift/EventLoop.h
@@ -229,7 +229,7 @@ private:
      * This function is a friend so it can pull pending requests and inject them into
      * the EventLoop.
      *
-     * @param async The async object trigger, this will always be m_async.
+     * @param handle The async object trigger, this will always be m_async.
      */
     friend auto requests_accept_async(
         uv_async_t* handle) -> void;

--- a/inc/lift/RequestStatus.h
+++ b/inc/lift/RequestStatus.h
@@ -18,6 +18,7 @@ enum class RequestStatus {
     RESPONSE_EMPTY, ///< The request has an empty response (socket severed).
 
     ERROR, ///< The request had an error and failed.
+    ERROR_FAILED_TO_START, ///< The request had an error and failed to start.
     DOWNLOAD_ERROR ///< The request had an error in the CURL write callback.
 };
 

--- a/src/RequestStatus.cpp
+++ b/src/RequestStatus.cpp
@@ -2,16 +2,19 @@
 
 namespace lift {
 
-static const std::string REQUEST_STATUS_BUILDING = "BUILDING";
-static const std::string REQUEST_STATUS_EXECUTING = "EXECUTING";
-static const std::string REQUEST_STATUS_SUCCESS = "SUCCESS";
-static const std::string REQUEST_STATUS_CONNECT_ERROR = "CONNECT_ERROR";
-static const std::string REQUEST_STATUS_CONNECT_DNS_ERROR = "CONNECT_DNS_ERROR";
-static const std::string REQUEST_STATUS_CONNECT_SSL_ERROR = "CONNECT_SSL_ERROR";
-static const std::string REQUEST_STATUS_TIMEOUT = "TIMEOUT";
-static const std::string REQUEST_STATUS_RESPONSE_EMPTY = "RESPONSE_EMPTY";
-static const std::string REQUEST_STATUS_ERROR = "ERROR";
-static const std::string REQUEST_STATUS_DOWNLOAD_ERROR = "DOWNLOAD_ERROR";
+using namespace std::string_literals;
+
+static const std::string REQUEST_STATUS_BUILDING = "BUILDING"s;
+static const std::string REQUEST_STATUS_EXECUTING = "EXECUTING"s;
+static const std::string REQUEST_STATUS_SUCCESS = "SUCCESS"s;
+static const std::string REQUEST_STATUS_CONNECT_ERROR = "CONNECT_ERROR"s;
+static const std::string REQUEST_STATUS_CONNECT_DNS_ERROR = "CONNECT_DNS_ERROR"s;
+static const std::string REQUEST_STATUS_CONNECT_SSL_ERROR = "CONNECT_SSL_ERROR"s;
+static const std::string REQUEST_STATUS_TIMEOUT = "TIMEOUT"s;
+static const std::string REQUEST_STATUS_RESPONSE_EMPTY = "RESPONSE_EMPTY"s;
+static const std::string REQUEST_STATUS_ERROR_FAILED_TO_START = "ERROR_FAILED_TO_START"s;
+static const std::string REQUEST_STATUS_ERROR = "ERROR"s;
+static const std::string REQUEST_STATUS_DOWNLOAD_ERROR = "DOWNLOAD_ERROR"s;
 
 auto to_string(RequestStatus request_status) -> const std::string&
 {
@@ -34,6 +37,8 @@ auto to_string(RequestStatus request_status) -> const std::string&
         return REQUEST_STATUS_RESPONSE_EMPTY;
     case RequestStatus::DOWNLOAD_ERROR:
         return REQUEST_STATUS_DOWNLOAD_ERROR;
+    case RequestStatus::ERROR_FAILED_TO_START:
+        return REQUEST_STATUS_ERROR_FAILED_TO_START;
     case RequestStatus::ERROR:
     default:
         return REQUEST_STATUS_ERROR;


### PR DESCRIPTION
This fixes a bug where if "Expect: 100-continue" is sent
by curl the liblift library will handle the events properly.