### PR TITLE
Attempt2 :: Provide new method for the Request Object to change the CURLOPT_SSL_V…

### DIFF
--- a/inc/lift/Request.h
+++ b/inc/lift/Request.h
@@ -231,6 +231,18 @@ public:
     auto GetNumConnects() const -> uint64_t;
     
     /**
+     * Set the verify behavior of the CURLOPT_SSL_VERIFYPEER on the curl_handle
+     * @param verify the verify value to set the CURLOPT_SSL_VERIFYPEER option to
+     */
+    auto SetVerifySSLPeer(int64_t verify) -> void;
+
+    /**
+     * Set the verify behavior of the CURLOPT_SSL_VERIFYHOST on the curl_handle
+     * @param verify the verify value to set the CURLOPT_SSL_VERIFYHOST option to
+     */
+    auto SetVerifySSLHostAndPeer(int64_t verify) -> void;
+
+    /**
      * Resets the request to be re-used.  This will clear everything on the request.
      */
     auto Reset() -> void;

--- a/inc/lift/Request.h
+++ b/inc/lift/Request.h
@@ -231,6 +231,18 @@ public:
     auto GetNumConnects() const -> uint64_t;
     
     /**
+     * Set the verify behavior of the CURLOPT_SSL_VERIFYPEER on the curl_handle
+     * @param verify the verify value to set the CURLOPT_SSL_VERIFYPEER option to
+     */
+    auto SetVerifySSLPeer(int64_t verify) -> void;
+
+    /**
+     * Set the verify behavior of the CURLOPT_SSL_VERIFYHOST on the curl_handle
+     * @param verify the verify value to set the CURLOPT_SSL_VERIFYHOST option to
+     */
+    auto SetVerifySSLHost(int64_t verify) -> void;
+
+    /**
      * Resets the request to be re-used.  This will clear everything on the request.
      */
     auto Reset() -> void;

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -332,6 +332,16 @@ auto Request::GetCompletionStatus() const -> RequestStatus
     return m_status_code;
 }
 
+auto Request::SetVerifySSLPeer(int64_t verify) -> void
+{
+    curl_easy_setopt(m_curl_handle, CURLOPT_SSL_VERIFYPEER, verify);
+}
+
+auto Request::SetVerifySSLHost(int64_t verify) -> void
+{
+    curl_easy_setopt(m_curl_handle, CURLOPT_SSL_VERIFYHOST, verify);
+}
+
 auto Request::Reset() -> void
 {
     m_url = std::string_view {};

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -95,7 +95,7 @@ auto Request::SetUrl(const std::string& url) -> bool
 auto Request::GetNumConnects() const -> uint64_t
 {
     long count = 0;
-    curl_easy_getinfo(m_handle.GetValue(), CURLINFO_NUM_CONNECTS, &count);
+    curl_easy_getinfo(m_curl_handle, CURLINFO_NUM_CONNECTS, &count);
 
     return static_cast<uint64_t>(count);
 }
@@ -330,6 +330,16 @@ auto Request::GetTotalTime() const -> std::chrono::milliseconds
 auto Request::GetCompletionStatus() const -> RequestStatus
 {
     return m_status_code;
+}
+
+auto Request::SetVerifySSLPeer(int64_t verify) -> void
+{
+    curl_easy_setopt(m_curl_handle, CURLOPT_SSL_VERIFYPEER, verify);
+}
+
+auto Request::SetVerifySSLHost(int64_t verify) -> void
+{
+    curl_easy_setopt(m_curl_handle, CURLOPT_SSL_VERIFYHOST, verify);
 }
 
 auto Request::Reset() -> void


### PR DESCRIPTION
…ERIFYHOST and CURLOPT_SSL_VERIFYPEER values

	-Useful when particular apps are not concerned with verifying the host and peer in ssl connections
		-For example when connecting to internal apps that may not have legitamite certs.