### PR TITLE
Timesup fixes

### DIFF
--- a/examples/async_batch_requests.cpp
+++ b/examples/async_batch_requests.cpp
@@ -8,12 +8,14 @@
 
 static auto on_complete(lift::RequestHandle request_handle) -> void
 {
+    using namespace std::chrono_literals;
+
     auto& request = *request_handle;
     switch (request.GetCompletionStatus()) {
     case lift::RequestStatus::SUCCESS:
         std::cout
             << "Completed " << request.GetUrl()
-            << " ms:" << request.GetTotalTime().count() << std::endl;
+            << " ms:" << request.GetTotalTime().value_or(0ms).count() << std::endl;
         break;
     case lift::RequestStatus::CONNECT_ERROR:
         std::cout << "Unable to connect to: " << request.GetUrl() << std::endl;

--- a/examples/async_post_requests.cpp
+++ b/examples/async_post_requests.cpp
@@ -4,12 +4,13 @@
 
 static auto on_complete(lift::RequestHandle request_handle) -> void
 {
+    using namespace std::chrono_literals;
     auto& request = *request_handle;
     switch (request.GetCompletionStatus()) {
         case lift::RequestStatus::SUCCESS:
             std::cout
                 << "Completed " << request.GetUrl()
-                << " ms:" << request.GetTotalTime().count() << std::endl;
+                << " ms:" << request.GetTotalTime().value_or(0ms).count() << std::endl;
             break;
         case lift::RequestStatus::CONNECT_ERROR:
             std::cout << "Unable to connect to: " << request.GetUrl() << std::endl;

--- a/examples/async_response_time_limit.cpp
+++ b/examples/async_response_time_limit.cpp
@@ -10,11 +10,13 @@ static uint64_t response_count{0};
 
 static auto on_complete(lift::RequestHandle request_handle) -> void
 {
+    using namespace std::chrono_literals;
+
     auto& request = *request_handle;
     std::cout << "For request with url " << request.GetUrl() << ", ";
     if (request.GetCompletionStatus() == lift::RequestStatus::SUCCESS) {
         ++response_count;
-        std::cout << "requested was successfully completed in " << request.GetTotalTime().count() << " ms" << std::endl;
+        std::cout << "requested was successfully completed in " << request.GetTotalTime().value_or(0ms).count() << " ms" << std::endl;
         std::cout << "Received response body was: " << request.GetResponseData() << std::endl;
     } else {
         ++timeout_count;

--- a/examples/async_simple.cpp
+++ b/examples/async_simple.cpp
@@ -8,11 +8,13 @@
 
 static auto on_complete(lift::RequestHandle request_handle) -> void
 {
+    using namespace std::chrono_literals;
+
     auto& request = *request_handle;
     if (request.GetCompletionStatus() == lift::RequestStatus::SUCCESS) {
         std::cout
             << "Completed " << request.GetUrl()
-            << " ms:" << request.GetTotalTime().count() << std::endl;
+            << " ms:" << request.GetTotalTime().value_or(0ms).count() << std::endl;
     } else {
         std::cout
             << "Error: " << request.GetUrl() << " : "

--- a/examples/async_simple_max_bytes.cpp
+++ b/examples/async_simple_max_bytes.cpp
@@ -8,11 +8,13 @@
 
 static auto on_complete(lift::RequestHandle request_handle) -> void
 {
+    using namespace std::chrono_literals;
+
     auto& request = *request_handle;
     if (request.GetCompletionStatus() == lift::RequestStatus::SUCCESS) {
         std::cout
             << "Completed " << request.GetUrl()
-            << " in " << request.GetTotalTime().count() << " ms with a "
+            << " in " << request.GetTotalTime().value_or(0ms).count() << " ms with a "
             << "result length of " << request.GetResponseData().length() << std::endl
             << std::endl;
     } else {

--- a/inc/lift/EventLoop.h
+++ b/inc/lift/EventLoop.h
@@ -275,8 +275,12 @@ private:
      *          a RequestHandle and return the Request to the RequestPool if necessary.
      * @param response_wait_time_timeout Bool indicating whether or not onComplete was called because
      *          a response wait time was exceeded (true) or not (false)
+     * @param finish_time Optional that will contain a uint64_t indicating the timepoint when
+     *                    the request was timed out while waiting for the response time.
+     *                    If the request received a response or timed out via cURL, this will be
+     *                    empty and we'll get the total time from the cURL handle.
      */
-    friend auto Request::onComplete(EventLoop& event_loop, std::shared_ptr<SharedRequest> shared_request, bool response_wait_time_timeout) -> void;
+    friend auto Request::onComplete(EventLoop& event_loop, std::shared_ptr<SharedRequest> shared_request, std::optional<uint64_t> finish_time) -> void;
 };
 
 } // lift

--- a/inc/lift/Request.h
+++ b/inc/lift/Request.h
@@ -11,7 +11,6 @@
 #include <chrono>
 #include <filesystem>
 #include <functional>
-#include <iostream>
 #include <set>
 #include <string>
 #include <string_view>

--- a/inc/lift/Request.h
+++ b/inc/lift/Request.h
@@ -235,7 +235,8 @@ public:
     auto GetResponseData() const -> const std::string&;
 
     /**
-     * @return The total HTTP request time in milliseconds.
+     * @return The total HTTP request time in milliseconds as an optional (will be empty
+     *          if the request has not finished yet).
      */
     [[nodiscard]]
     auto GetTotalTime() const -> const std::optional<std::chrono::milliseconds>&

--- a/src/EventLoop.cpp
+++ b/src/EventLoop.cpp
@@ -3,7 +3,6 @@
 #include <curl/multi.h>
 
 #include <chrono>
-#include <iostream>
 #include <thread>
 
 using namespace std::chrono_literals;
@@ -214,21 +213,21 @@ auto EventLoop::stopTimedOutRequests() -> void
         // itself up at the end of this method.
         auto& data = current_wrapper->GetData();
         auto shared_request = data.m_shared_request_ptr_pointer;
-    
+
         // Update current_wrapper with the result of removing the wrapper from the multiset
         current_wrapper = removeTimeoutByIterator(current_wrapper);
-    
+
         // Call onComplete on the underlying Request object, copying in the shared_pointer
         // so we get a correct reference count.
         shared_request->GetAsReference().onComplete(*this, shared_request, true);
     }
-    
+
     // If there are still items in the multiset, get the first item and use its time to reset the request timer.
     if (!m_response_wait_time_wrappers.empty())
     {
         auto& request_time = m_response_wait_time_wrappers.begin()->GetData().m_timeout_time;
         uv_timer_stop(&m_response_timer);
-    
+
         uv_timer_start(
             &m_response_timer,
             on_response_wait_time_expired_callback,
@@ -241,10 +240,10 @@ auto EventLoop::removeTimeoutByIterator(std::multiset<ResponseWaitTimeWrapper>::
 {
     // Get a reference to the SharedRequest pointed to by the shared pointer.
     auto& shared_request = *request_to_remove->GetData().m_shared_request_ptr_pointer;
-    
+
     // Reset the iterator stored on the Request so it can't be reused.
     shared_request.GetAsReference().m_response_wait_time_set_iterator.reset();
-    
+
     return m_response_wait_time_wrappers.erase(request_to_remove);
 }
 
@@ -282,12 +281,14 @@ auto EventLoop::checkActions(
             CURLcode easy_result = message->data.result;
 
             // So the reacquired shared_ptr destructs itself correctly, let's get it into a unique pointer
-            std::unique_ptr<std::shared_ptr<SharedRequest>> shared_request_ptr_pointer;
-            curl_easy_getinfo(easy_handle, CURLINFO_PRIVATE, &shared_request_ptr_pointer);
+            std::shared_ptr<SharedRequest>* curl_info_private_pointer{nullptr};
+            curl_easy_getinfo(easy_handle, CURLINFO_PRIVATE, &curl_info_private_pointer);
             curl_multi_remove_handle(m_cmh, easy_handle);
 
+            std::unique_ptr<std::shared_ptr<SharedRequest>> shared_request_ptr_pointer{curl_info_private_pointer};
+
             auto shared_request_ptr = *shared_request_ptr_pointer;
-            
+
             shared_request_ptr->GetAsReference().setCompletionStatus(easy_result);
             shared_request_ptr->GetAsReference().onComplete(*this, shared_request_ptr);
 
@@ -421,7 +422,7 @@ auto on_uv_curl_perform_callback(
 auto requests_accept_async(uv_async_t* handle) -> void
 {
     auto* event_loop = static_cast<EventLoop*>(handle->data);
-    
+
     /**
      * This lock must not have any "curl_*" functions called
      * while it is held, curl has its own internal locks and
@@ -440,7 +441,7 @@ auto requests_accept_async(uv_async_t* handle) -> void
     for (auto& request_handle : event_loop->m_grabbed_requests)
     {
         auto& raw_request = *request_handle;
-        
+
         // If there's a response wait time, we'll need to create a ResponseWaitTimeWrapper and add
         // it to the wrapper multiset so it can be handled in the event it takes too long to respond.
         if (const auto& response_wait_time_opt = raw_request.GetResponseWaitTime(); response_wait_time_opt.has_value())
@@ -448,33 +449,39 @@ auto requests_accept_async(uv_async_t* handle) -> void
             // Get the current timepoint from libuv (it caches the current timepoint at the beginning
             // of every cycle through the event loop, so this should not be expensive).
             auto time = uv_now(event_loop->m_loop);
-            
+
             const auto request_timeout = response_wait_time_opt.value();
             auto next_timepoint = time + static_cast<uint64_t>(request_timeout.count());
-        
+
             auto& wrappers = event_loop->m_response_wait_time_wrappers;
-            
+
             if (wrappers.empty() || next_timepoint < wrappers.begin()->GetData().m_timeout_time)
             {
                 uv_timer_stop(&event_loop->m_response_timer);
-    
+
                 uv_timer_start(
                     &event_loop->m_response_timer,
                     on_response_wait_time_expired_callback,
                     static_cast<uint64_t>(request_timeout.count()),
                     0);
             }
-        
+
             auto iterator = event_loop->m_response_wait_time_wrappers.emplace(next_timepoint,
                                                                               request_handle.m_shared_request);
             request_handle->setTimeoutIterator(iterator);
         }
-    
+
         // Create a shared_ptr to the SharedRequest on the heap so its lifetime is maintained after exiting this function.
         auto shared_request_on_heap = request_handle.createSharedRequestOnHeap();
-        
+
+        // Set the pointer to the shared pointer to the SharedRequest on the curl handle so we can get it back
+        // when the callback is called. (We'll release it from the unique pointer later if the call
+        // curl_multi_add_handle does not return an error.)
+        request_handle->setSharedPointerOnCurlHandle(shared_request_on_heap.get());
+
+        request_handle->setStartTime();
         auto curl_code = curl_multi_add_handle(event_loop->m_cmh, raw_request.m_curl_handle);
-    
+
         if(curl_code != CURLM_OK && curl_code != CURLM_CALL_MULTI_PERFORM)
         {
             /**
@@ -484,23 +491,23 @@ auto requests_accept_async(uv_async_t* handle) -> void
             request_handle->setCompletionStatus(CURLcode::CURLE_SEND_ERROR);
 
             // If we are calling onComplete now, move the shared_ptr into the method so it cleans itself up correctly.
-            request_handle->onComplete(*event_loop, std::move(*shared_request_on_heap));
+            request_handle->onComplete(*event_loop, *shared_request_on_heap);
         }
         else
         {
-            // We are going to wait for a response, so we need to set pointer to the shared pointer on the request
-            // so we can get it back later in checkActions.
-            raw_request.setSharedPointerOnCurlHandle(shared_request_on_heap.release());
-            
             /**
              * Immediately call curl's check action to get the current request moving.
              * Curl appears to have an internal queue and if it gets too long it might
              * drop requests.
              */
             event_loop->checkActions();
+
+            // We are going to wait for a response, so we need to release the pointer to the shared pointer so we can
+            // get it back later in checkActions.
+            (void)shared_request_on_heap.release();
         }
     }
-    
+
     event_loop->m_grabbed_requests.clear();
 }
 

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -38,10 +38,6 @@ Request::Request(
     {
         SetResponseWaitTime(response_wait_time.value());
     }
-
-    // Set the private pointer in the curl handle to a nullptr, because we want to
-    // set it explicity for every new SharedRequest in requests_accept_async.
-    setSharedPointerOnCurlHandle(nullptr);
 }
 
 Request::~Request()
@@ -88,11 +84,11 @@ auto Request::setTotalTime(std::optional<uint64_t> finish_time) -> void
     }
     else
     {
-        constexpr uint64_t SEC_2_MS = 1000;
-
         double total_time = 0;
         curl_easy_getinfo(m_curl_handle, CURLINFO_TOTAL_TIME, &total_time);
-        m_total_time.emplace(std::chrono::milliseconds{static_cast<int64_t>(total_time * SEC_2_MS)});
+
+        // std::duration defaults to seconds, so don't need to duration_cast total time to seconds.
+        m_total_time.emplace(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::duration<double>{total_time}));
     }
 }
 

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -3,7 +3,6 @@
 #include "lift/RequestHandle.h"
 
 #include <cstring>
-#include <iostream>
 
 namespace lift {
 auto curl_write_header(
@@ -392,7 +391,6 @@ auto Request::Reset() -> void
     }
 
     clearResponseBuffers();
-
     curl_easy_reset(m_curl_handle);
     init();
     m_status_code = RequestStatus::BUILDING;

--- a/src/RequestPool.cpp
+++ b/src/RequestPool.cpp
@@ -80,6 +80,10 @@ auto RequestPool::Produce(
         request_handle_ptr->SetOnCompleteHandler(std::move(on_complete_handler));
         request_handle_ptr->SetUrl(url);
         request_handle_ptr->SetCurlTimeout(curl_timeout);
+        if (response_wait_time.has_value())
+        {
+            request_handle_ptr->SetResponseWaitTime(response_wait_time.value());
+        }
         
         return RequestHandle { *this, std::move(request_handle_ptr) };
     }


### PR DESCRIPTION
Move setSharedPointerOnCurlHandle before call to curl_multi_add_handle to handle cases where checkActions is called during call to curl_multi_add_handle. Also updated GetTotalTime to return either timeout time after time out due to response wait time OR curl's total time, whichever is applicable.