### PR TITLE
Modify Connection lifetimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
                         clang-9 \
                         zlib1g-dev \
                         libcurl4-openssl-dev \
+                        libssl-dev \
                         libuv1-dev \
                         curl \
                         wget
@@ -104,6 +105,7 @@ jobs:
                         lcov \
                         zlib-devel \
                         libcurl-devel \
+                        openssl-devel \
                         libuv-devel \
                         iputils \
                         curl \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,17 @@ jobs:
             -   name: check-haproxy
                 run: |
                     curl -v --user guest:guestpassword -x "http://haproxy:3128" "http://nginx/index.html"
+            -   name: build-libcurl
+                run: |
+                    # We have to custom build libcurl because we need a new configuration option.
+                    # Stolen from jbaldwin's upstream
+                    wget https://github.com/curl/curl/releases/download/curl-7_86_0/curl-7.86.0.tar.gz
+                    gunzip curl-7.86.0.tar.gz
+                    tar -xf curl-7.86.0.tar
+                    cd curl-7.86.0/
+                    ./configure --with-openssl
+                    make -j $(nproc)
+                    make install
             -   name: build-release-g++
                 run: |
                     mkdir build-release-g++
@@ -101,6 +112,17 @@ jobs:
             -   name: check-haproxy
                 run: |
                     curl -v --user guest:guestpassword -x "http://haproxy:3128" "http://nginx/index.html"
+            -   name: build-libcurl
+                run: |
+                    # We have to custom build libcurl because we need a new configuration option.
+                    # Stolen from jbaldwin's upstream
+                    wget https://github.com/curl/curl/releases/download/curl-7_86_0/curl-7.86.0.tar.gz
+                    gunzip curl-7.86.0.tar.gz
+                    tar -xf curl-7.86.0.tar
+                    cd curl-7.86.0/
+                    ./configure --with-openssl
+                    make -j $(nproc)
+                    make install
             -   name: build-debug-g++
                 run: |
                     mkdir build-debug-g++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
                         zlib1g-dev \
                         libcurl4-openssl-dev \
                         libuv1-dev \
-                        curl
+                        curl \
+                        wget
             -   name: check-haproxy
                 run: |
                     curl -v --user guest:guestpassword -x "http://haproxy:3128" "http://nginx/index.html"
@@ -105,7 +106,8 @@ jobs:
                         libcurl-devel \
                         libuv-devel \
                         iputils \
-                        curl
+                        curl \
+                        wget
             -   name: ping
                 run: |
                     ping -c1 nginx

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -142,6 +142,10 @@ auto executor::prepare() -> void
         }
     }
 
+    // Add a max lifetime for connections and time them out a little faster so we get better goodput.
+    curl_easy_setopt(m_curl_handle, CURLOPT_MAXAGE_CONN, 28L);
+    curl_easy_setopt(m_curl_handle, CURLOPT_MAXLIFETIME_CONN, 600L);
+    
     // Connection timeout is handled when injecting into the CURLM* event loop for asynchronous requests.
 
     if (m_request->follow_redirects())

--- a/test/test_proxy.cpp
+++ b/test/test_proxy.cpp
@@ -51,7 +51,7 @@ TEST_CASE("proxy Basic Auth")
     {
         if (header.name() == "server")
         {
-            REQUIRE(header.value() == "nginx/1.18.0");
+            REQUIRE(header.value() == "nginx/1.22.1");
         }
         else if (header.name() == "content-length")
         {
@@ -84,7 +84,7 @@ TEST_CASE("proxy Any Auth")
     {
         if (header.name() == "server")
         {
-            REQUIRE(header.value() == "nginx/1.18.0");
+            REQUIRE(header.value() == "nginx/1.22.1");
         }
         else if (header.name() == "content-length")
         {

--- a/test/test_proxy.cpp
+++ b/test/test_proxy.cpp
@@ -18,7 +18,7 @@ TEST_CASE("proxy")
     {
         if (header.name() == "server")
         {
-            REQUIRE(header.value() == "nginx/1.18.0");
+            REQUIRE(header.value() == "nginx/1.22.1");
         }
         else if (header.name() == "content-length")
         {


### PR DESCRIPTION
Set CURLOPT_MAXAGE_CONN to 28 seconds as we see connections timeout at 30 seconds. Set CURLOPT_MAXLIFETIME_CONN to 10 minutes so that we cycle connections and do not attempt to use old connections forever, as curl seems to let us try bad connections over and over